### PR TITLE
Update IPFS version in Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Get Kubo Version
+        id: kubo_version
+        run: |
+          echo "IPFS_TAG=v$(jq .devDependencies.kubo ./package.json | sed 's/[\^"]//g')" >> $GITHUB_OUTPUT
 
       # Docker build
       - name: Setup QEMU
@@ -164,6 +168,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
+          build-args: |
+            IPFS_TAG=${{ steps.kubo_version.outputs.IPFS_TAG }}
           tags: |
             ghcr.io/${{ needs.preconditions.outputs.org_name }}/${{ needs.preconditions.outputs.repo_name }}:${{ needs.check-version.outputs.version }}
             ${{ needs.preconditions.outputs.org_name }}/${{ needs.preconditions.outputs.repo_name }}:${{ needs.check-version.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - name: Get Kubo Version
+        id: kubo_version
+        run: |
+          echo "IPFS_TAG=v$(jq .devDependencies.kubo ./package.json | sed 's/[\^"]//g')" >> $GITHUB_OUTPUT
       # Docker build
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -139,3 +142,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64, linux/arm64
+          build-args: |
+            IPFS_TAG=${{ steps.kubo_version.outputs.IPFS_TAG }}
+            

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache git make bash gcc musl-dev
 
 WORKDIR /target
 
-ARG IPFS_TAG="v0.26.0"
+ARG IPFS_TAG="v0.31.0"
 
 RUN <<EOF
 set -ex

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.10
 
-FROM golang:1.21-alpine3.17 AS ipfs_build
+FROM golang:1.23-alpine3.19 AS ipfs_build
 
-ENV SRC_DIR /go/src/github.com/ipfs/kubo
+ENV SRC_DIR=/go/src/github.com/ipfs/kubo
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then apk add --no-cache binutils-gold; fi
 
@@ -10,25 +10,28 @@ RUN apk add --no-cache git make bash gcc musl-dev
 
 WORKDIR /target
 
-ARG IPFS_TAG="v0.31.0"
+ARG IPFS_TAG=NO_VALUE
+RUN [ ! "${IPFS_TAG}" == "NO_VALUE" ]
+
+RUN echo $IPFS_TAG
 
 RUN <<EOF
 set -ex
-git clone --branch $IPFS_TAG https://github.com/ipfs/kubo.git $SRC_DIR
+git clone --branch "$IPFS_TAG" https://github.com/ipfs/kubo.git $SRC_DIR
 cd $SRC_DIR
 make build
 cp $SRC_DIR/cmd/ipfs/ipfs /target/ipfs
 rm -rf $SRC_DIR
 EOF
 
-FROM node:lts-alpine3.17 AS runtime
+FROM node:lts-alpine3.19 AS runtime
 ARG TARGETPLATFORM
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then apk add --no-cache python3 make g++; fi
 RUN apk add --no-cache curl
 RUN npm i -g npm@latest
 
 ARG LOGLEVEL
-ENV NPM_CONFIG_LOGLEVEL ${LOGLEVEL}
+ENV NPM_CONFIG_LOGLEVEL=${LOGLEVEL}
 
 COPY --from=ipfs_build /target /usr/local/bin
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sqnc-ipfs
 
-Manages a go-ipfs instance maintaining the private network swarm key based on the value from a `sqnc-node` instance.
+Manages a [kubo](https://docs.ipfs.tech/install/command-line/) instance maintaining the private network swarm key based on the value from a `sqnc-node` instance.
 
 ## Local development
 > install dependencies
@@ -31,3 +31,11 @@ npm run dev
 | IPFS_EXECUTABLE               |    N     |    `ipfs`    | Executable to use to run go-ipfs                                                     |
 | IPFS_ARGS                     |    N     | `["daemon"]` | JSON array of strings to pass as arguments to the `IPFS_EXECUTABLE`                  |
 | IPFS_LOG_LEVEL                |    N     |    `info`    | Log level of the go-ipfs child process                                               |
+
+## Docker build
+
+`sqnc-ipfs` can be built into a docker container. There is a required build argument for this `IPFS_TAG` which specifies what version of `kubo` should be built into `sqnc-ipfs`. The container can therefore be built using:
+
+```sh
+docker build --build-arg IPFS_TAG="v0.31.0" .
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "2.10.90",
+  "version": "2.10.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-ipfs",
-      "version": "2.10.90",
+      "version": "2.10.91",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "2.10.90",
+  "version": "2.10.91",
   "description": "IPFS node for use in SQNC",
   "main": "app/index.js",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-23

## High level description

Set the build arg `IPFS_TAG` based on the version of `kubo` configured as a `devDependency`

## Detailed description

We need this for two reasons:
1. it ensures we always build releases against the same version of kubo as used in the tests
2. It ensures the version of `kubo` is kept up-to-date

## Describe alternatives you've considered

At the moment the extraction of the version number happens in the workflow and passed in as an arg. We could do this in the build by copying over `package.json` but that would make layer caching worseas now any change to the package will result in a new Kubo image being built.

## Operational impact

None

## Additional context

N/A
