### PR TITLE
Switch to a debian base image to support ipfs migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ git clone --branch "$IPFS_TAG" https://github.com/ipfs/kubo.git $SRC_DIR
 cd $SRC_DIR
 make build
 cp $SRC_DIR/cmd/ipfs/ipfs /target/ipfs
+rm -rf $SRC_DIR
 EOF
 
 FROM node:lts-bookworm AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 # syntax=docker/dockerfile:1.14
 
-FROM golang:1.23-alpine3.19 AS ipfs_build
+FROM golang:1.23-bookworm AS ipfs_build
 
 ENV SRC_DIR=/go/src/github.com/ipfs/kubo
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then apk add --no-cache binutils-gold; fi
-
-RUN apk add --no-cache git make bash gcc musl-dev
 
 WORKDIR /target
 
 ARG IPFS_TAG=NO_VALUE
-RUN [ ! "${IPFS_TAG}" == "NO_VALUE" ]
+RUN [ "$IPFS_TAG" != "NO_VALUE" ]
 
 RUN echo $IPFS_TAG
 
@@ -21,13 +18,10 @@ git clone --branch "$IPFS_TAG" https://github.com/ipfs/kubo.git $SRC_DIR
 cd $SRC_DIR
 make build
 cp $SRC_DIR/cmd/ipfs/ipfs /target/ipfs
-rm -rf $SRC_DIR
 EOF
 
-FROM node:lts-alpine3.19 AS runtime
+FROM node:lts-bookworm AS runtime
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then apk add --no-cache python3 make g++; fi
-RUN apk add --no-cache curl
 RUN npm i -g npm@latest
 
 ARG LOGLEVEL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-ipfs",
-      "version": "3.0.17",
+      "version": "3.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "3.0.17",
+  "version": "3.0.18",
   "description": "IPFS node for use in SQNC",
   "main": "app/index.js",
   "type": "module",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-135

## High level description

Switch to a debian image so we can run migrations

## Detailed description

IPFS data migrations are fetched dynamically. As these are not built for musl this is an issue. Switching to a debian based image should resolve this

## Describe alternatives you've considered

nuke IPFS from orbit. Unfortunately not an option at this time

## Operational impact

This could definitely go wrong if there's some weird stuff in the IPFS data directory (for example binaries). We will need to test this in staging and make sure data has migrated successfuly by executing `GET /attachment/{id}` for different attachments.

## Additional context

None
