### PR TITLE
Enable Trivy container CVE scan (ENG-314)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       packages: write
       security-events: write
     with:
+      scan_container: true
       push_dockerhub: true
       push_ghcr: true
       build_args: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,6 @@ jobs:
       packages: write
       security-events: write
     with:
+      scan_container: true
       build_args: |
         IPFS_TAG=${{ needs.kubo-version.outputs.ipfs_tag }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-ipfs",
-      "version": "3.0.110",
+      "version": "3.0.111",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-ipfs",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "description": "IPFS node for use in SQNC",
   "main": "app/index.js",
   "type": "module",


### PR DESCRIPTION
## Linked tickets

[ENG-314](https://digicatapult.atlassian.net/browse/ENG-314)

## High level description

Enables the Trivy container CVE scan by setting `scan_container: true` on the shared `build-docker` call (test and release). The built `linux/amd64` image is scanned with a digest-pinned Trivy; the build fails on CRITICAL findings and uploads a JSON report artifact (no GHAS upload). Scan runs in an isolated least-privilege job.

## PR Type

- [x] Chore

## Operational impact

CI-only. Adds an isolated scan job to the docker build on PR and release. Fails the build on CRITICAL image CVEs.

[ENG-314]: https://digicatapult.atlassian.net/browse/ENG-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ